### PR TITLE
Commands via chat

### DIFF
--- a/futebot/BotUtils.py
+++ b/futebot/BotUtils.py
@@ -162,3 +162,17 @@ def strip_command_name(name):
     n = strip_accents(name.lower().strip())
     n = re.sub(r"[\s\-]", "", n)
     return n
+
+def extract_command(line):
+    """
+    {assunto|comando}{:|-}$command
+    <$command>
+    [$command]
+    """
+    line = line.lower().strip()
+    p = r'<([\w ]+)>|\[([\w ]+)\]|(?:assunto|comando)\s*[:\-]\s*([\w ]+)'
+    cmd = re.search(p,line,re.UNICODE)
+    if cmd:
+        return [group for group in cmd.groups() if group is not None][0].replace(" ","")
+    else:
+        return line.replace(" ","")

--- a/futebot/CommandHandler.py
+++ b/futebot/CommandHandler.py
@@ -6,7 +6,7 @@ import os
 from ErrorPrinter import print_error
 from DB import db_session
 from Models import Sub
-from BotUtils import strip_command_name, format_sub_name, format_user_name
+from BotUtils import strip_command_name, format_sub_name, format_user_name, extract_command
 from prawcore import PrawcoreException
 
 BOT_ADMIN = (os.environ.get('BOT_ADMIN') or "BOT_ADMIN not found at os.env").lower()
@@ -17,7 +17,7 @@ def try_command(pm):
         return True
     
     # Cancel PM and marks as read without executing anything if unknown command
-    command = find_command_name(pm.subject)
+    command = find_command_name(pm)
     if not command:
         return True
     
@@ -87,8 +87,14 @@ def try_command(pm):
         print_error(e)
         return False
 
-def find_command_name(comm):
-    comm = strip_command_name(comm)
+def find_command_name(msg):
+    #given a Message, find the command either on the subject of a pm, or on the first line of a chat
+    CHAT_SUBJECT = "[direct chat room]"
+    if msg.subject == CHAT_SUBJECT:
+        comm = extract_command(msg.body.replace(';','\n').split('\n')[0])
+    else:
+        comm = strip_command_name(msg.subject)        
+
     if comm in command_data:
         return comm
     


### PR DESCRIPTION
resolves #10 
Adds support to commands via chat. Pm with subject remains unchanged. for chat commands, the FIRST LINE must contain the command following one of these formatting options:
`[cmd]`
`<cmd>`
`comando:cmd`
`comando-cmd`
`assunto:cmd`
`assunto-cmd`
(blank spaces are allowed)
Full set of instructions must be in a single chat message (a single "send"), arguments must be separated by either a ";" delimiter or a new line.